### PR TITLE
feat(f13): Azurite as Lazy Dependency — auto-detect, install, start/stop

### DIFF
--- a/fnx/lib/azurite-manager.js
+++ b/fnx/lib/azurite-manager.js
@@ -1,0 +1,197 @@
+import { spawn, execSync } from 'node:child_process';
+import { createConnection } from 'node:net';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const BLOB_PORT = 10000;
+const QUEUE_PORT = 10001;
+const TABLE_PORT = 10002;
+const AZURITE_INSTALL_DIR = join(homedir(), '.fnx', 'tools', 'azurite');
+
+let azuriteProcess = null;
+
+/**
+ * Determine whether Azurite is needed based on AzureWebJobsStorage value.
+ * Returns true for "UseDevelopmentStorage=true", empty string, or missing key.
+ */
+function needsAzurite(mergedValues) {
+  const connStr = mergedValues?.AzureWebJobsStorage;
+  if (!connStr || connStr === '') return true;
+  if (connStr === 'UseDevelopmentStorage=true') return true;
+  return false;
+}
+
+/**
+ * TCP probe — resolves true if a connection can be established on the given port.
+ */
+function isPortInUse(port, host = '127.0.0.1', timeoutMs = 1000) {
+  return new Promise((resolve) => {
+    const socket = createConnection({ port, host });
+    const timer = setTimeout(() => { socket.destroy(); resolve(false); }, timeoutMs);
+    socket.on('connect', () => { clearTimeout(timer); socket.destroy(); resolve(true); });
+    socket.on('error', () => { clearTimeout(timer); socket.destroy(); resolve(false); });
+  });
+}
+
+/**
+ * Wait until a TCP port becomes reachable (up to timeoutMs).
+ */
+async function waitForTcp(port, { host = '127.0.0.1', timeoutMs = 15000, intervalMs = 300 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isPortInUse(port, host, 500)) return true;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return false;
+}
+
+/**
+ * Check if Azurite default ports are already in use.
+ */
+async function isAzuriteRunning() {
+  return await isPortInUse(BLOB_PORT);
+}
+
+/**
+ * Find an existing azurite binary (global install, npx, or cached in ~/.fnx/tools/azurite).
+ * Returns the path/command or null.
+ */
+function findAzurite() {
+  // 1. Check the fnx tools cache first
+  const cachedBin = join(AZURITE_INSTALL_DIR, 'node_modules', '.bin', 'azurite');
+  if (existsSync(cachedBin)) return cachedBin;
+
+  // 2. Check global PATH
+  try {
+    const which = execSync('which azurite', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+    if (which) return which;
+  } catch { /* not found */ }
+
+  return null;
+}
+
+/**
+ * Install azurite into ~/.fnx/tools/azurite/ if not already present.
+ */
+function installAzurite() {
+  console.log('[fnx] Installing Azurite to ~/.fnx/tools/azurite/ (first-time only)...');
+  mkdirSync(AZURITE_INSTALL_DIR, { recursive: true });
+
+  // Initialize a minimal package.json if missing so npm install works
+  const pkgPath = join(AZURITE_INSTALL_DIR, 'package.json');
+  if (!existsSync(pkgPath)) {
+    writeFileSync(pkgPath, JSON.stringify({ name: 'fnx-azurite-cache', private: true }, null, 2));
+  }
+
+  try {
+    execSync('npm install azurite --save --loglevel=error', {
+      cwd: AZURITE_INSTALL_DIR,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 120_000,
+    });
+  } catch (err) {
+    console.error('[fnx] Failed to install Azurite. Install manually: npm install -g azurite');
+    console.error(`      ${err.message}`);
+    return null;
+  }
+
+  const installed = join(AZURITE_INSTALL_DIR, 'node_modules', '.bin', 'azurite');
+  if (existsSync(installed)) {
+    console.log('[fnx] Azurite installed successfully.');
+    return installed;
+  }
+  return null;
+}
+
+/**
+ * Find azurite binary, installing if necessary.
+ */
+function findOrInstallAzurite() {
+  let bin = findAzurite();
+  if (bin) return bin;
+  return installAzurite();
+}
+
+/**
+ * Main entry point: ensure Azurite is available and running if needed.
+ * Returns the child process (caller kills on exit), or null if not started.
+ */
+export async function ensureAzurite(mergedValues, opts = {}) {
+  if (opts.noAzurite) {
+    return null;
+  }
+
+  if (!needsAzurite(mergedValues)) {
+    return null;
+  }
+
+  const storageVal = mergedValues?.AzureWebJobsStorage || '(empty)';
+  console.log(`[fnx] Detected AzureWebJobsStorage=${storageVal}`);
+
+  // Check if Azurite is already running
+  if (await isAzuriteRunning()) {
+    console.log('[fnx] Using existing Azurite instance on default ports.');
+    return null;
+  }
+
+  // Find or install azurite
+  const azuriteBin = findOrInstallAzurite();
+  if (!azuriteBin) {
+    console.error('[fnx] ⚠️  Azurite not available. Storage triggers may fail.');
+    console.error('     Install with: npm install -g azurite');
+    return null;
+  }
+
+  console.log('[fnx] Starting Azurite storage emulator...');
+
+  const azuriteArgs = [
+    '--blobHost', '127.0.0.1', '--blobPort', String(BLOB_PORT),
+    '--queueHost', '127.0.0.1', '--queuePort', String(QUEUE_PORT),
+    '--tableHost', '127.0.0.1', '--tablePort', String(TABLE_PORT),
+    '--silent',
+    '--location', join(homedir(), '.fnx', 'azurite-data'),
+  ];
+
+  // Ensure data directory exists
+  mkdirSync(join(homedir(), '.fnx', 'azurite-data'), { recursive: true });
+
+  azuriteProcess = spawn(azuriteBin, azuriteArgs, {
+    stdio: 'ignore',
+  });
+
+  azuriteProcess.on('error', (err) => {
+    console.error(`[fnx] Azurite failed to start: ${err.message}`);
+    azuriteProcess = null;
+  });
+
+  azuriteProcess.on('exit', (code) => {
+    if (code && code !== 0) {
+      console.error(`[fnx] Azurite exited unexpectedly with code ${code}.`);
+    }
+    azuriteProcess = null;
+  });
+
+  // Wait for Azurite to be ready
+  const ready = await waitForTcp(BLOB_PORT, { timeoutMs: 15000 });
+  if (!ready) {
+    console.error('[fnx] ⚠️  Azurite did not become ready in time. Storage triggers may fail.');
+    return azuriteProcess;
+  }
+
+  console.log(`[fnx] Azurite Blob  → http://127.0.0.1:${BLOB_PORT}`);
+  console.log(`[fnx] Azurite Queue → http://127.0.0.1:${QUEUE_PORT}`);
+  console.log(`[fnx] Azurite Table → http://127.0.0.1:${TABLE_PORT}`);
+
+  return azuriteProcess;
+}
+
+/**
+ * Stop the managed Azurite process.
+ */
+export function stopAzurite() {
+  if (azuriteProcess) {
+    try { azuriteProcess.kill(); } catch { /* already dead */ }
+    azuriteProcess = null;
+  }
+}

--- a/fnx/lib/cli.js
+++ b/fnx/lib/cli.js
@@ -41,6 +41,7 @@ export async function main(args) {
   const mcpPort = getFlag(args, '--mcp-port') || String(parseInt(port) + 1);
   const verbose = args.includes('--verbose');
   const noMcp = args.includes('--no-mcp');
+  const noAzurite = args.includes('--no-azurite');
   const profilesSource = getFlag(args, '--profiles');
 
   // Set profiles source before any profile resolution
@@ -167,6 +168,7 @@ export async function main(args) {
     profile,
     verbose,
     hostState,
+    noAzurite,
   });
 }
 
@@ -242,6 +244,7 @@ Options:
   --port <port>    Port for the host HTTP listener. Default: 7071.
   --mcp-port <p>   Port for the live MCP server. Default: host port + 1 (7072).
   --no-mcp         Disable the live MCP server (host-only mode).
+  --no-azurite     Skip automatic Azurite start (for users who manage Azurite separately).
   --profiles <src> SKU profiles source. Can be:
                    • A URL (http/https) to a profiles JSON endpoint
                    • A local file path to a profiles JSON file

--- a/fnx/lib/host-launcher.js
+++ b/fnx/lib/host-launcher.js
@@ -4,6 +4,7 @@ import { platform, homedir } from 'node:os';
 import { createInterface } from 'node:readline';
 import { existsSync } from 'node:fs';
 import { getHostExeName } from './host-manager.js';
+import { ensureAzurite, stopAzurite } from './azurite-manager.js';
 
 // ─── Shared host state (consumed by live MCP server) ─────────────────────
 // This object is populated by the log filter and exposed for the MCP server.
@@ -105,58 +106,6 @@ function findPythonExecutable(scriptRoot, explicitPath) {
     } catch { /* not found */ }
   }
   return null;
-}
-
-// ─── Azurite (local storage emulator) ───────────────────────────────────
-// When AzureWebJobsStorage=UseDevelopmentStorage=true, the host expects
-// Azurite to be running. We auto-start it so developers don't get stuck.
-
-let azuriteProcess = null;
-
-function startAzuriteIfNeeded(env) {
-  if (env.AzureWebJobsStorage !== 'UseDevelopmentStorage=true') return;
-
-  // Check if Azurite is already running on default port (10000)
-  try {
-    execSync('curl -sf http://127.0.0.1:10000/ -o /dev/null 2>&1', { stdio: 'ignore', timeout: 2000 });
-    console.log('  Azurite:         already running on port 10000');
-    return;
-  } catch { /* not running */ }
-
-  // Try to find azurite
-  let azuriteBin;
-  try {
-    azuriteBin = execSync('which azurite', { encoding: 'utf-8' }).trim();
-  } catch {
-    try {
-      // Try npx path
-      azuriteBin = execSync('npm root -g', { encoding: 'utf-8' }).trim() + '/azurite/dist/src/azurite.js';
-      if (!existsSync(azuriteBin)) azuriteBin = null;
-    } catch { azuriteBin = null; }
-  }
-
-  if (!azuriteBin) {
-    console.log('  ⚠️  AzureWebJobsStorage=UseDevelopmentStorage=true but azurite not found.');
-    console.log('     Install with: npm install -g azurite');
-    return;
-  }
-
-  console.log('  Azurite:         auto-starting (UseDevelopmentStorage=true)');
-  azuriteProcess = spawn('azurite', ['--silent', '--location', '/tmp/azurite-fnx', '--blobHost', '127.0.0.1', '--queueHost', '127.0.0.1', '--tableHost', '127.0.0.1'], {
-    stdio: 'ignore',
-    detached: true,
-  });
-  azuriteProcess.unref();
-
-  // Give Azurite a moment to start
-  execSync('sleep 1');
-}
-
-function stopAzurite() {
-  if (azuriteProcess) {
-    try { process.kill(-azuriteProcess.pid); } catch { /* already dead */ }
-    azuriteProcess = null;
-  }
 }
 
 // ─── Log filtering (mirrors Core Tools ColoredConsoleLogger behavior) ───
@@ -395,8 +344,8 @@ export async function launchHost(hostDir, opts) {
     }
   }
 
-  // Auto-start Azurite if needed
-  startAzuriteIfNeeded(env);
+  // Auto-start Azurite if needed (lazy install + TCP readiness probe)
+  const azuriteProc = await ensureAzurite(opts.mergedValues, { noAzurite: opts.noAzurite });
 
   console.log();
   console.log('Azure Functions Local Emulator (fnx — Phoenix Emulate)');


### PR DESCRIPTION
## F13: Azurite as Lazy Dependency

Makes Azurite automatically available when storage triggers need it, eliminating the manual install/start friction for new developers.

### What was implemented

| File | Change |
|------|--------|
| `fnx/lib/azurite-manager.js` | **New** — full Azurite lifecycle manager |
| `fnx/lib/host-launcher.js` | Replaced 44-line inline Azurite logic with `ensureAzurite()`/`stopAzurite()` imports |
| `fnx/lib/cli.js` | Added `--no-azurite` opt-out flag + help text |

### Key behaviors

- **Auto-detect**: starts Azurite when `AzureWebJobsStorage` is `UseDevelopmentStorage=true`, empty, or missing
- **Lazy install**: `npm install azurite` to `~/.fnx/tools/azurite/` only on first need (no cost for non-storage users)
- **Port reuse**: if ports 10000–10002 are occupied, assumes existing Azurite and skips start
- **TCP readiness probe**: waits up to 15s for blob port using `node:net` (zero external deps)
- **Graceful shutdown**: SIGINT/SIGTERM kills Azurite child process
- **`--no-azurite` flag**: explicit opt-out for users managing Azurite themselves
- **No impact on `fnx templates-mcp`**: Azurite logic only runs during `fnx start`

### Verification steps

```bash
# 1. Detect UseDevelopmentStorage=true
cat test-node-app/local.settings.json

# 2. Azurite auto-starts (if not already running)
node fnx/bin/fnx start --sku flex --scriptroot ./test-node-app 2>&1 | head -20
# Expected: "[fnx] Starting Azurite storage emulator..." or "Using existing Azurite"

# 3. --no-azurite flag skips Azurite
node fnx/bin/fnx start --sku flex --scriptroot ./test-node-app --no-azurite 2>&1 | head -10
# Expected: No Azurite start attempt

# 4. Existing CLI still works
node fnx/bin/fnx start --sku list
```

### Spec
See `docs/prd-docs/f13-azurite-dependency.md`