### PR TITLE
feat(f7): Install-Time Warmup — fnx warmup command + postinstall hook

### DIFF
--- a/fnx/lib/cli.js
+++ b/fnx/lib/cli.js
@@ -30,6 +30,12 @@ export async function main(args) {
     return;
   }
 
+  if (cmd === 'warmup') {
+    const { warmup } = await import('./warmup.js');
+    await warmup(args.slice(1));
+    return;
+  }
+
   if (cmd !== 'start') {
     console.error(`Unknown command: ${cmd}\n`);
     printHelp();
@@ -231,6 +237,8 @@ Usage: fnx <action> [-/--options]
 Actions:
   start            Launch the Azure Functions host runtime for a specific SKU.
                    Downloads and caches the correct host version automatically.
+  warmup           Pre-download host binaries and extension bundles for offline use.
+                   Runs automatically as postinstall hook. Use --dry-run to preview.
   templates-mcp    Start the Azure Functions templates MCP server (stdio transport).
                    Drop-in replacement for manvir-templates-mcp-server.
                    Provides 68 templates across 4 languages via MCP protocol.

--- a/fnx/lib/host-manager.js
+++ b/fnx/lib/host-manager.js
@@ -25,13 +25,18 @@ function getHostExeName() {
     : 'Microsoft.Azure.WebJobs.Script.WebHost';
 }
 
-export async function ensureHost(profile) {
+export async function ensureHost(profile, { force = false } = {}) {
   const hostDir = join(HOST_CACHE, profile.hostVersion);
   const hostExe = join(hostDir, getHostExeName());
 
-  if (existsSync(hostExe)) {
+  if (!force && existsSync(hostExe)) {
     console.log('  Host cached, skipping download.');
     return hostDir;
+  }
+
+  // Clean existing dir if forcing re-download
+  if (force && existsSync(hostDir)) {
+    await rm(hostDir, { recursive: true, force: true });
   }
 
   // Determine download URL
@@ -178,7 +183,7 @@ function findBestBundleVersion(allVersions, range, maxVersion) {
   return candidates[candidates.length - 1]; // highest valid version
 }
 
-export async function ensureBundle(profile) {
+export async function ensureBundle(profile, { force = false } = {}) {
   const bundleDir = join(BUNDLE_CACHE, BUNDLE_ID);
   const range = profile.extensionBundleVersion;
   const maxVersion = profile.maxExtensionBundleVersion;
@@ -207,9 +212,14 @@ export async function ensureBundle(profile) {
   }
 
   const versionDir = join(bundleDir, bestVersion);
-  if (existsSync(join(versionDir, 'bundle.json'))) {
+  if (!force && existsSync(join(versionDir, 'bundle.json'))) {
     console.log(`  Bundle ${bestVersion} cached.`);
     return bestVersion;
+  }
+
+  // Clean existing version dir if forcing re-download
+  if (force && existsSync(versionDir)) {
+    await rm(versionDir, { recursive: true, force: true });
   }
 
   // Download and extract
@@ -267,4 +277,4 @@ function findCachedBundle(bundleDir, range, maxVersion) {
   return best;
 }
 
-export { getHostExeName };
+export { getHostExeName, getPlatformRid };

--- a/fnx/lib/warmup.js
+++ b/fnx/lib/warmup.js
@@ -1,0 +1,203 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { resolveProfile, listProfiles } from './profile-resolver.js';
+import { ensureHost, ensureBundle, getHostExeName, getPlatformRid } from './host-manager.js';
+
+const FNX_DIR = join(homedir(), '.fnx');
+const META_FILE = join(FNX_DIR, '_meta.json');
+const HOST_CACHE = join(FNX_DIR, 'hosts');
+const BUNDLE_CACHE = join(FNX_DIR, 'bundles');
+const BUNDLE_ID = 'Microsoft.Azure.Functions.ExtensionBundle';
+
+function getFlag(args, flag) {
+  const idx = args.indexOf(flag);
+  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : null;
+}
+
+export async function warmup(args) {
+  try {
+    await runWarmup(args);
+  } catch (err) {
+    // Never crash — postinstall must not break npm install
+    console.error(`fnx warmup: ${err.message}`);
+  }
+}
+
+async function runWarmup(args) {
+  if (args.includes('-h') || args.includes('--help')) {
+    printWarmupHelp();
+    return;
+  }
+
+  if (process.env.FNX_SKIP_DOWNLOAD === '1') {
+    console.log('fnx warmup: skipped (FNX_SKIP_DOWNLOAD=1)');
+    return;
+  }
+
+  const dryRun = args.includes('--dry-run');
+  const force = args.includes('--force');
+  const all = args.includes('--all');
+  let sku = getFlag(args, '--sku');
+
+  if (sku === 'list') {
+    await listProfiles();
+    return;
+  }
+
+  let targetSkus;
+  if (all) {
+    targetSkus = await getAllSkuNames();
+  } else {
+    sku = sku || process.env.FNX_DEFAULT_SKU || 'flex';
+    targetSkus = [sku];
+  }
+
+  const rid = getPlatformRid();
+
+  console.log();
+  console.log(`fnx warmup — pre-downloading assets for ${all ? 'ALL SKUs' : 'offline use'}`);
+  console.log();
+  console.log(`  Platform:        ${rid}`);
+
+  const meta = await loadMeta();
+
+  for (const skuName of targetSkus) {
+    try {
+      console.log();
+      const profile = await resolveProfile(skuName);
+
+      console.log(`  Target SKU:      ${profile.displayName} (${skuName})`);
+      console.log(`  Host Version:    ${profile.hostVersion}`);
+      if (profile.maxExtensionBundleVersion) {
+        console.log(`  Bundle Range:    ${profile.extensionBundleVersion} (max: ${profile.maxExtensionBundleVersion})`);
+      }
+      console.log();
+
+      if (dryRun) {
+        printDryRun(profile, force);
+        continue;
+      }
+
+      // Download host + bundle (reuse existing ensureHost/ensureBundle)
+      const hostDir = await ensureHost(profile, { force });
+      const bundleVersion = await ensureBundle(profile, { force });
+
+      // Update meta
+      if (!meta.warmedSkus.includes(skuName)) {
+        meta.warmedSkus.push(skuName);
+      }
+      meta.hosts[profile.hostVersion] = {
+        rid,
+        downloadedAt: new Date().toISOString(),
+      };
+      if (bundleVersion) {
+        meta.bundles[bundleVersion] = {
+          downloadedAt: new Date().toISOString(),
+        };
+      }
+
+      console.log();
+      console.log(`  ✓ fnx start --sku ${skuName} will work offline.`);
+    } catch (err) {
+      console.error(`  ⚠️  Warmup failed for ${skuName}: ${err.message}`);
+    }
+  }
+
+  if (!dryRun) {
+    meta.fnxVersion = await getFnxVersion();
+    meta.installedAt = new Date().toISOString();
+    meta.platform = rid;
+    await saveMeta(meta);
+  }
+
+  console.log();
+  console.log('  Done.');
+  console.log();
+}
+
+function printDryRun(profile, force) {
+  const hostExePath = join(HOST_CACHE, profile.hostVersion, getHostExeName());
+  const hostCached = !force && existsSync(hostExePath);
+
+  const bundleDir = join(BUNDLE_CACHE, BUNDLE_ID);
+  const bundleCached = !force && findAnyCachedBundle(bundleDir);
+
+  console.log(`  [1/3] Profiles                  ✓ resolved`);
+  console.log(`  [2/3] Host ${profile.hostVersion.padEnd(14)} ${hostCached ? '✓ cached' : '↓ needs download'}`);
+  console.log(`  [3/3] Bundle                    ${bundleCached ? `✓ cached (${bundleCached})` : '↓ needs download'}`);
+}
+
+function findAnyCachedBundle(bundleDir) {
+  try {
+    const dirs = readdirSync(bundleDir);
+    for (const d of dirs) {
+      if (existsSync(join(bundleDir, d, 'bundle.json'))) {
+        return d;
+      }
+    }
+  } catch { /* not cached */ }
+  return null;
+}
+
+async function getAllSkuNames() {
+  try {
+    const profilesPath = new URL('../profiles/sku-profiles.json', import.meta.url).pathname;
+    const registry = JSON.parse(await readFile(profilesPath, 'utf-8'));
+    return Object.keys(registry.profiles);
+  } catch {
+    return ['flex', 'linux-premium', 'windows-consumption', 'windows-dedicated', 'linux-consumption'];
+  }
+}
+
+async function loadMeta() {
+  try {
+    return JSON.parse(await readFile(META_FILE, 'utf-8'));
+  } catch {
+    return { warmedSkus: [], hosts: {}, bundles: {} };
+  }
+}
+
+async function saveMeta(meta) {
+  await mkdir(FNX_DIR, { recursive: true });
+  await writeFile(META_FILE, JSON.stringify(meta, null, 2));
+}
+
+async function getFnxVersion() {
+  try {
+    const pkgPath = new URL('../package.json', import.meta.url).pathname;
+    const pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
+    return pkg.version;
+  } catch {
+    return 'unknown';
+  }
+}
+
+function printWarmupHelp() {
+  console.log(`
+fnx warmup — Pre-download host binaries and extension bundles for offline use.
+
+Usage: fnx warmup [options]
+
+Options:
+  --sku <name>     Target SKU to warm (default: flex). Use --sku list to see options.
+  --all            Warm ALL available SKUs (useful for CI/build agents).
+  --dry-run        Show what would be downloaded without actually downloading.
+  --force          Re-download even if already cached.
+  -h, --help       Show this help message.
+
+Environment Variables:
+  FNX_SKIP_DOWNLOAD=1       Skip warmup entirely (useful for CI/Docker).
+  FNX_DEFAULT_SKU=<name>    Warm a specific SKU instead of flex.
+
+Examples:
+  fnx warmup                            Pre-download default SKU (flex)
+  fnx warmup --sku flex                 Explicit SKU
+  fnx warmup --sku windows-consumption  Warm a specific SKU
+  fnx warmup --sku list                 Show available SKUs
+  fnx warmup --all                      Warm ALL SKUs
+  fnx warmup --dry-run                  Show what would be downloaded
+  fnx warmup --force                    Re-download even if cached
+`.trim());
+}

--- a/fnx/package.json
+++ b/fnx/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "fnx": "./bin/fnx"
   },
+  "scripts": {
+    "postinstall": "node ./bin/fnx warmup || echo 'fnx: warmup skipped (offline or error). Run fnx warmup manually.'"
+  },
   "dependencies": {},
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary

Implements **F7: Install-Time Warmup** per `docs/prd-docs/f7-install-warmup.md`.

Adds a `fnx warmup` command that pre-downloads the Azure Functions host binary (~200MB) and extension bundle (~155MB) at install time, so `fnx start` works offline without a surprise first-run download. Wired as an npm `postinstall` hook with fault-tolerant fallback.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `fnx/lib/warmup.js` | **Created** | Full warmup command: resolve profile → download host → download bundle → write cache metadata |
| `fnx/lib/cli.js` | Modified | Added `warmup` subcommand routing + help text |
| `fnx/lib/host-manager.js` | Modified | Exported `getPlatformRid`; added backward-compatible `{ force }` option to `ensureHost()`/`ensureBundle()` |
| `fnx/package.json` | Modified | Added `postinstall` hook with `\|\| echo` fallback |

## Features

- **Flags:** `--sku <name>`, `--all`, `--dry-run`, `--force`, `--help`
- **Env vars:** `FNX_SKIP_DOWNLOAD=1` (skip warmup for CI/Docker), `FNX_DEFAULT_SKU=<name>` (override default SKU)
- **Cache metadata:** Writes `~/.fnx/_meta.json` tracking fnx version, platform, warmed SKUs, host/bundle info
- **Fault tolerance:** Outer try/catch ensures warmup never crashes; postinstall `\|\| echo` ensures `npm install` never fails

## Verification

```bash
# 1. Warmup command exists
node fnx/bin/fnx warmup --help 2>&1
# ✅ Shows usage with --sku, --all, --dry-run, --force flags

# 2. Dry run shows what would be downloaded
node fnx/bin/fnx warmup --dry-run 2>&1
# ✅ Shows platform (osx-arm64), SKU, host version, cached/needs-download status

# 3. Skip download env var works
FNX_SKIP_DOWNLOAD=1 node fnx/bin/fnx warmup 2>&1
# ✅ Prints "warmup skipped (FNX_SKIP_DOWNLOAD=1)"

# 4. Existing CLI commands still work
node fnx/bin/fnx start --sku list
# ✅ SKU profile table displays correctly
```

All 4 checks pass.