### PR TITLE
docs: update FRD statuses — F6-F13 implemented

### DIFF
--- a/docs/prd-docs/README.md
+++ b/docs/prd-docs/README.md
@@ -11,10 +11,16 @@ Individual feature specs broken out from the [PRD](../prd.md). Each FRD is self-
 | F3 | [Extension Bundle Support](./f3-extension-bundle-support.md) | ✅ POC validated | SKU-aware bundle version resolution + auto-download |
 | F4 | [CLI Surface & Config](./f4-cli-surface-config.md) | ✅ POC validated | `--sku` flag, config merging, help UX |
 | F5 | [Non-HTTP Trigger Support](./f5-non-http-triggers.md) | ✅ POC validated | Blob/Timer/Queue trigger indexing, display, and execution |
-| F6 | [MCP Server Integration](./f6-mcp-server.md) | 📋 Proposed | Expose fnx runtime + templates as an MCP server |
-| F7 | [Install-Time Warmup](./f7-install-warmup.md) | 📋 Proposed | Pre-download host + bundle during `npm install` |
-| F8 | [Homepage Improvements](./f8-homepage-improvements.md) | 📋 Proposed | Transform host homepage into a developer productivity hub |
+| F6 | [MCP Server Integration](./f6-mcp-server.md) | ✅ Implemented | Expose fnx runtime + templates as an MCP server |
+| F7 | [Install-Time Warmup](./f7-install-warmup.md) | ✅ Implemented | Pre-download host + bundle during `npm install` |
+| F8 | [Homepage Improvements](./f8-homepage-improvements.md) | ✅ Implemented | Transform host homepage into a developer productivity hub |
+| F9 | [.NET Isolated Worker Only](./f9-dotnet-isolated-only.md) | ✅ Implemented | Block in-process .NET projects with migration guidance |
+| F10 | [Standalone Template MCP Server](./f10-template-mcp-standalone.md) | ✅ Implemented | Fast, host-free MCP server entrypoint for AI agents |
+| F11 | [Debugging & Logging Test Rigor](./f11-debugging-logging-rigor.md) | ✅ Implemented | Test framework + unit/E2E tests for logging and debugging |
+| F12 | [Comprehensive E2E & Unit Tests](./f12-comprehensive-testing.md) | ✅ Implemented | Full test suite for Template MCP + emulator |
+| F13 | [Azurite as Lazy Dependency](./f13-azurite-dependency.md) | ✅ Implemented | Auto-detect, install, and start Azurite for storage triggers |
+| F14 | [npm Release & Distribution](./f14-npm-release.md) | 📋 Proposed | npm publish plan for `fnx` package |
 
 ## Relationship to PRD
 
-The PRD (`docs/prd.md`) defines the overall vision: make `func start` SKU-aware. These FRDs break the implementation into shippable units. F1–F5 were validated in the fnx POC. F6 is a new capability that extends fnx with AI-tooling integration.
+The PRD (`docs/prd.md`) defines the overall vision: make `func start` SKU-aware. These FRDs break the implementation into shippable units. F1–F5 were validated in the fnx POC. F6–F13 have been implemented. F14 covers npm distribution.

--- a/docs/prd-docs/f10-template-mcp-standalone.md
+++ b/docs/prd-docs/f10-template-mcp-standalone.md
@@ -1,6 +1,6 @@
 # F10: Standalone Template MCP Server — Fast, Host-Free
 
-**Status:** 📋 Proposed  
+**Status:** ✅ Implemented  
 **PRD Section:** MCP server  
 **Depends on:** F6 (MCP server)
 

--- a/docs/prd-docs/f11-debugging-logging-rigor.md
+++ b/docs/prd-docs/f11-debugging-logging-rigor.md
@@ -1,6 +1,6 @@
 # F11: Debugging & Logging Test Rigor — Matching Core Tools
 
-**Status:** 📋 Proposed  
+**Status:** ✅ Implemented  
 **PRD Section:** Testing & quality  
 **Depends on:** F4 (CLI surface)  
 **Source:** Core Tools repo (`azure-functions-core-tools/test/Cli/`)

--- a/docs/prd-docs/f12-comprehensive-testing.md
+++ b/docs/prd-docs/f12-comprehensive-testing.md
@@ -1,6 +1,6 @@
 # F12: Comprehensive E2E & Unit Tests — Template MCP + Emulator
 
-**Status:** 📋 Proposed  
+**Status:** ✅ Implemented  
 **PRD Section:** Testing & quality  
 **Depends on:** F6 (MCP server), F11 (test infrastructure)
 

--- a/docs/prd-docs/f13-azurite-dependency.md
+++ b/docs/prd-docs/f13-azurite-dependency.md
@@ -1,6 +1,6 @@
 # F13: Azurite as Lazy Dependency for Local Storage Emulation
 
-**Status:** 📋 Proposed  
+**Status:** ✅ Implemented  
 **PRD Section:** Local development experience  
 **Depends on:** F1 (SKU profiles), F4 (CLI surface)
 

--- a/docs/prd-docs/f6-mcp-server.md
+++ b/docs/prd-docs/f6-mcp-server.md
@@ -1,6 +1,6 @@
 # F6: MCP Server Integration
 
-**Status:** 📋 Proposed  
+**Status:** ✅ Implemented  
 **PRD Section:** N/A (new capability)  
 **Depends on:** F1 (profiles), F2 (host manager), F5 (trigger support)
 

--- a/docs/prd-docs/f7-install-warmup.md
+++ b/docs/prd-docs/f7-install-warmup.md
@@ -1,6 +1,6 @@
 # F7: Install-Time Warmup (`fnx warmup`)
 
-**Status:** 📋 Proposed  
+**Status:** ✅ Implemented  
 **PRD Section:** 6.6 (Host Version Management)  
 **Depends on:** F1 (profiles), F2 (host manager), F3 (extension bundles)
 

--- a/docs/prd-docs/f8-homepage-improvements.md
+++ b/docs/prd-docs/f8-homepage-improvements.md
@@ -1,6 +1,6 @@
 # F8: Homepage Improvements
 
-**Status:** 📋 Proposed  
+**Status:** ✅ Implemented  
 **PRD Section:** N/A (new initiative)  
 **Depends on:** None (Phase 1); F2 host version info (Phase 2)
 

--- a/docs/prd-docs/f9-dotnet-isolated-only.md
+++ b/docs/prd-docs/f9-dotnet-isolated-only.md
@@ -1,6 +1,6 @@
 # F9: .NET Isolated Worker Only — No In-Process Model
 
-**Status:** 📋 Proposed  
+**Status:** ✅ Implemented  
 **PRD Section:** Runtime support  
 **Depends on:** F1 (SKU profiles), F2 (host version manager)
 


### PR DESCRIPTION
Updates all FRD status markers after Wave 1 + Wave 2 implementation:

| FRD | Before | After |
|-----|--------|-------|
| F6–F13 | 📋 Proposed | ✅ Implemented |
| F14 | 📋 Proposed | 📋 Proposed (unchanged) |

Also adds F9–F14 to the README index table (were previously missing).