### PR TITLE
Expose packaging as `fnx pack`

### DIFF
--- a/fnx/README.md
+++ b/fnx/README.md
@@ -57,6 +57,7 @@ fnx start --sku <sku> --scriptroot <path>   # Run function app
 fnx start --sku list                         # List available SKUs
 fnx warmup [--sku <sku>] [--all]            # Pre-download host + bundle
 fnx templates-mcp                            # Start MCP server for AI agents
+fnx pack --scriptroot <path>                # Package function app as deployment zip
 ```
 
 ## MCP Server (for AI Agents)

--- a/fnx/lib/cli.js
+++ b/fnx/lib/cli.js
@@ -7,6 +7,7 @@ import { ensureHost, ensureBundle } from './host-manager.js';
 import { launchHost, createHostState } from './host-launcher.js';
 import { startLiveMcpServer } from './live-mcp-server.js';
 import { detectDotnetModel, printInProcessError } from './dotnet-detector.js';
+import { detectRuntimeFromConfig, packFunctionApp } from './pack.js';
 
 function isPortFree(port) {
   return new Promise((resolve) => {
@@ -50,6 +51,15 @@ export async function main(args) {
   if (cmd === 'warmup') {
     const { warmup } = await import('./warmup.js');
     await warmup(args.slice(1));
+    return;
+  }
+
+  if (cmd === 'pack') {
+    const scriptRoot = getFlag(args, '--scriptroot') || process.cwd();
+    const runtime = getFlag(args, '--runtime') || await detectRuntimeFromConfig(scriptRoot);
+    const outputPath = getFlag(args, '--output');
+    const noBuild = args.includes('--no-build');
+    await packFunctionApp({ scriptRoot, runtime, outputPath, noBuild });
     return;
   }
 
@@ -239,6 +249,8 @@ Usage: fnx <action> [-/--options]
 Actions:
   start            Launch the Azure Functions host runtime for a specific SKU.
                    Downloads and caches the correct host version automatically.
+  pack             Package a Functions app into a deployment zip (func pack equivalent).
+                   Supports python, node, java, powershell, and dotnet-isolated.
   warmup           Pre-download host binaries and extension bundles for offline use.
                    Runs automatically as postinstall hook. Use --dry-run to preview.
   templates-mcp    Start the Azure Functions templates MCP server (stdio transport).
@@ -261,6 +273,10 @@ Options:
                    • Inline JSON string (e.g. '{"profiles":{...}}')
                    Default: FUNC_PROFILES_URL env var, or http://localhost:4566/api/profiles.
   --verbose        Show all host output (unfiltered). Default: clean output only.
+  --runtime <name> Runtime used by pack. If omitted, reads FUNCTIONS_WORKER_RUNTIME
+                   from app.config.json/local.settings.json.
+  --output <file>  Output zip path for pack. Default: <scriptroot-name>.zip.
+  --no-build       Skip build steps for java/dotnet-isolated during pack.
   -v, --version    Display the version of fnx.
   -h, --help       Display this help information.
 
@@ -287,6 +303,7 @@ Examples:
   fnx start --sku list                List all available SKU profiles with host versions
   fnx start --sku flex --port 8080    Start on a custom port
   fnx start --scriptroot ./my-app     Start from a specific function app directory
+  fnx pack --scriptroot ./my-app      Package function app as zip deployment artifact
 
 Side-by-side comparison:
   # Terminal 1: Run as Flex Consumption

--- a/fnx/lib/pack.js
+++ b/fnx/lib/pack.js
@@ -1,0 +1,140 @@
+import { basename, resolve as resolvePath, join } from 'node:path';
+import { access, constants, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { spawn } from 'node:child_process';
+
+const RUNTIME_ALIASES = new Map([
+  ['node', 'node'],
+  ['nodejs', 'node'],
+  ['javascript', 'node'],
+  ['typescript', 'node'],
+  ['python', 'python'],
+  ['py', 'python'],
+  ['java', 'java'],
+  ['powershell', 'powershell'],
+  ['pwsh', 'powershell'],
+  ['dotnet-isolated', 'dotnet-isolated'],
+  ['dotnetisolated', 'dotnet-isolated'],
+]);
+
+export const SUPPORTED_PACK_RUNTIMES = ['python', 'node', 'java', 'powershell', 'dotnet-isolated'];
+
+function normalizeRuntime(input) {
+  return String(input || '').trim().toLowerCase();
+}
+
+export function resolvePackRuntime(input) {
+  const normalized = normalizeRuntime(input);
+
+  if (!normalized) {
+    throw new Error('Missing runtime. Set FUNCTIONS_WORKER_RUNTIME or pass --runtime.');
+  }
+
+  if (normalized === 'dotnet') {
+    throw new Error('Only .NET isolated worker is supported for packing. Use dotnet-isolated runtime.');
+  }
+
+  const runtime = RUNTIME_ALIASES.get(normalized);
+  if (!runtime) {
+    throw new Error(
+      `Unsupported runtime '${input}'. Supported values: ${SUPPORTED_PACK_RUNTIMES.join(', ')}.`
+    );
+  }
+
+  return runtime;
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: options.silent ? 'pipe' : 'inherit',
+      env: process.env,
+    });
+
+    let stderr = '';
+    if (child.stderr) {
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
+    }
+
+    child.on('error', (err) => reject(err));
+    child.on('close', (code) => {
+      if (code === 0) return resolve();
+      reject(new Error(`${command} ${args.join(' ')} failed with code ${code}${stderr ? `: ${stderr.trim()}` : ''}`));
+    });
+  });
+}
+
+async function ensureExists(pathToCheck) {
+  await access(pathToCheck, constants.F_OK);
+}
+
+async function zipDirectory(sourceDir, outputZip) {
+  await runCommand('zip', ['-r', '-q', outputZip, '.'], { cwd: sourceDir });
+}
+
+async function stageJavaBuild(scriptRoot) {
+  await runCommand('mvn', ['clean', 'package', '-DskipTests'], { cwd: scriptRoot });
+  const targetDir = resolvePath(scriptRoot, 'target', 'azure-functions');
+  await ensureExists(targetDir);
+  return targetDir;
+}
+
+async function stageDotnetIsolatedBuild(scriptRoot, tempRoot) {
+  const publishDir = resolvePath(tempRoot, 'publish');
+  await runCommand('dotnet', ['publish', '--configuration', 'Release', '--output', publishDir], { cwd: scriptRoot });
+  await ensureExists(publishDir);
+  return publishDir;
+}
+
+export async function detectRuntimeFromConfig(scriptRoot) {
+  const appConfigPath = resolvePath(scriptRoot, 'app.config.json');
+  const localSettingsPath = resolvePath(scriptRoot, 'local.settings.json');
+
+  const parseIfExists = async (filePath) => {
+    try {
+      const raw = await readFile(filePath, 'utf-8');
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  };
+
+  const appConfig = await parseIfExists(appConfigPath);
+  const localSettings = await parseIfExists(localSettingsPath);
+  return appConfig?.Values?.FUNCTIONS_WORKER_RUNTIME || localSettings?.Values?.FUNCTIONS_WORKER_RUNTIME || null;
+}
+
+export async function packFunctionApp({ scriptRoot, runtime, outputPath, noBuild = false }) {
+  const root = resolvePath(scriptRoot || process.cwd());
+  const resolvedRuntime = resolvePackRuntime(runtime);
+  const resolvedOutput = resolvePath(outputPath || `${basename(root)}.zip`);
+
+  const tempRoot = await mkdtemp(join(tmpdir(), 'fnx-pack-'));
+
+  try {
+    let sourceDir = root;
+
+    if (!noBuild) {
+      if (resolvedRuntime === 'java') {
+        sourceDir = await stageJavaBuild(root);
+      } else if (resolvedRuntime === 'dotnet-isolated') {
+        sourceDir = await stageDotnetIsolatedBuild(root, tempRoot);
+      }
+    }
+
+    console.log(`Packing runtime '${resolvedRuntime}' from ${sourceDir}`);
+    await zipDirectory(sourceDir, resolvedOutput);
+    console.log(`Created package: ${resolvedOutput}`);
+
+    return {
+      runtime: resolvedRuntime,
+      sourceDir,
+      outputPath: resolvedOutput,
+    };
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}

--- a/tests/unit/pack.test.js
+++ b/tests/unit/pack.test.js
@@ -1,0 +1,42 @@
+import { describe, test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { resolvePackRuntime } from '../../fnx/lib/pack.js';
+
+describe('pack runtime resolution', () => {
+  const validCases = [
+    ['node', 'node'],
+    ['nodejs', 'node'],
+    ['javascript', 'node'],
+    ['typescript', 'node'],
+    ['python', 'python'],
+    ['py', 'python'],
+    ['java', 'java'],
+    ['powershell', 'powershell'],
+    ['pwsh', 'powershell'],
+    ['dotnet-isolated', 'dotnet-isolated'],
+    ['dotnetisolated', 'dotnet-isolated'],
+    ['  PYTHON  ', 'python'],
+  ];
+
+  for (const [input, expected] of validCases) {
+    test(`accepts '${input}'`, () => {
+      assert.strictEqual(resolvePackRuntime(input), expected);
+    });
+  }
+
+  const invalidCases = [
+    '',
+    '   ',
+    'dotnet',
+    'go',
+    'ruby',
+    'python3',
+    'node18',
+  ];
+
+  for (const input of invalidCases) {
+    test(`rejects '${input || '<empty>'}'`, () => {
+      assert.throws(() => resolvePackRuntime(input), /runtime|Unsupported|isolated/i);
+    });
+  }
+});


### PR DESCRIPTION
### Motivation
- Provide a contained implementation for packaging function apps and corresponding unit tests to validate runtime resolution and behavior.
- To match the `func pack` experience

### Description
- Updated CLI routing in `fnx/lib/cli.js` to dispatch `pack` and updated help text and examples to reference `pack` and its flags (`--runtime`, `--output`, `--no-build`).
- Added `fnx/lib/pack.js` implementing runtime normalization and validation (`resolvePackRuntime`), `detectRuntimeFromConfig`, build staging for `java` and `dotnet-isolated`, zipping logic, and `packFunctionApp` entrypoint.
- Added unit tests `tests/unit/pack.test.js` covering runtime alias acceptance and rejection cases for `resolvePackRuntime`.
- Updated `fnx/README.md` command list and examples to use `fnx pack`.

### Testing
- Ran unit tests with `node --test tests/unit/pack.test.js tests/unit/config-layering.test.js` and all tests passed (no failures).
- Verified CLI help output with `node fnx/bin/fnx --help | rg -n "^  pack|fix pack|--runtime <name> Runtime used by"` and confirmed help text shows `pack` and the `--runtime` description.
- The changes were committed as a focused update renaming the command and adding the packaging implementation.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699329075d44832982de603fa5745bb9)