### PR TITLE
fix: add missing closing brace for sync block and reorder dotnet detection

### DIFF
--- a/fnx/lib/cli.js
+++ b/fnx/lib/cli.js
@@ -57,7 +57,9 @@ export async function main(args) {
 
   if (cmd === 'sync') {
     await runSync(args.slice(1));
-    
+    return;
+  }
+
   if (cmd === 'pack') {
     const scriptRoot = getFlag(args, '--scriptroot') || process.cwd();
     const runtime = getFlag(args, '--runtime') || await detectRuntimeFromConfig(scriptRoot);
@@ -144,22 +146,7 @@ export async function main(args) {
   console.log(`  Profile Source:    ${source}`);
   console.log();
 
-  printHostDriftWarning(profile.hostVersion);
-
-  // 2. Ensure host is downloaded
-  const hostDir = await ensureHost(profile, { keepVersions: DEFAULT_KEEP_VERSIONS });
-  console.log(`  Host path:         ${hostDir}`);
-
-  // 3. Pre-download the correct extension bundle for this SKU
-  //    This resolves the exact version from CDN index, capped by maxExtensionBundleVersion,
-  //    and downloads it so the host finds it cached and never fetches a wrong version.
-  const resolvedBundleVersion = await ensureBundle(profile, { keepVersions: DEFAULT_KEEP_VERSIONS });
-  if (resolvedBundleVersion) {
-    console.log(`  Bundle resolved:   ${resolvedBundleVersion}`);
-  }
-  console.log();
-
-  // 4. Merge config: app.config.json Values + local.settings.json Values
+  // Early validation: merge config and check runtime before downloading anything
   const mergedValues = {
     ...(appConfig?.Values || {}),
     ...(localSettings?.Values || {}),
@@ -182,7 +169,22 @@ export async function main(args) {
     }
   }
 
-  // 5. Create shared host state and start live MCP server
+  printHostDriftWarning(profile.hostVersion);
+
+  // 2. Ensure host is downloaded
+  const hostDir = await ensureHost(profile, { keepVersions: DEFAULT_KEEP_VERSIONS });
+  console.log(`  Host path:         ${hostDir}`);
+
+  // 3. Pre-download the correct extension bundle for this SKU
+  //    This resolves the exact version from CDN index, capped by maxExtensionBundleVersion,
+  //    and downloads it so the host finds it cached and never fetches a wrong version.
+  const resolvedBundleVersion = await ensureBundle(profile, { keepVersions: DEFAULT_KEEP_VERSIONS });
+  if (resolvedBundleVersion) {
+    console.log(`  Bundle resolved:   ${resolvedBundleVersion}`);
+  }
+  console.log();
+
+  // 4. Create shared host state and start live MCP server
   const hostState = createHostState();
 
   if (!noMcp) {


### PR DESCRIPTION
## Problem

PR #21 introduced a **syntax error** in `fnx/lib/cli.js` — the `sync` command block was missing its closing `}` and `return;`. This caused the entire module to fail to parse, which broke:

- **All 12 MCP Protocol Tests** (all 3 platforms) — `Cannot read properties of undefined (reading 'result')` because `fnx templates-mcp` couldn't start
- **E2E dotnet in-process detection test** — CLI couldn't start at all

Additionally, PR #20 introduced an E2E failure where the dotnet in-process detection ran *after* host download, so a 404 on host download would mask the in-process error.

## Fix

1. **Add missing `}` and `return;`** after `runSync()` to properly close the `sync` block
2. **Move dotnet in-process detection and runtime validation before host/bundle download** — fail fast on incompatible projects without attempting expensive downloads

## Verification

- ✅ `node -c fnx/lib/cli.js` — syntax check passes
- ✅ 136 unit tests pass
- ✅ 30 MCP template tests pass
- ✅ Brace count balanced (127:127)