### PR TITLE
feat: Add microsoft org to trusted template sources

### DIFF
--- a/fnx/lib/init/manifest.js
+++ b/fnx/lib/init/manifest.js
@@ -21,7 +21,7 @@ const BUNDLED_MANIFEST_FILE = join(__dirname, '..', '..', 'templates', 'manifest
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 // Allowed GitHub organizations for template repositories
-const ALLOWED_ORGS = ['azure', 'azure-samples'];
+export const ALLOWED_ORGS = ['azure', 'azure-samples', 'microsoft'];
 
 /**
  * Filter templates to only include those from trusted Azure orgs

--- a/fnx/lib/init/scaffold.js
+++ b/fnx/lib/init/scaffold.js
@@ -23,6 +23,7 @@ import { randomUUID } from 'node:crypto';
 import { title, info, success, dim, bold, funcName } from '../colors.js';
 import { getDefaultVersion } from '../runtimes.js';
 import { createAppConfig } from '../config.js';
+import { ALLOWED_ORGS } from './manifest.js';
 
 /**
  * Validate that a file path is within the target directory (prevent path traversal)
@@ -99,9 +100,8 @@ export async function downloadTemplate(template, targetDir, manifest, options = 
 
   const [, owner, repo] = repoMatch;
   
-  // Security: Only allow Azure or Azure-Samples repos (defense against compromised manifest)
-  const allowedOrgs = ['azure', 'azure-samples'];
-  if (!allowedOrgs.includes(owner.toLowerCase())) {
+  // Security: Only allow trusted orgs (defense against compromised manifest)
+  if (!ALLOWED_ORGS.includes(owner.toLowerCase())) {
     const error = `Template references untrusted repository (${owner}/${repo}). Please report this issue.`;
     if (verbose) console.log(dim(`  Warning: ${error}`));
     return { success: false, filesDownloaded: 0, error };


### PR DESCRIPTION
Adds \microsoft\ to the allowed GitHub orgs for template sources, enabling templates like Agent Framework Multi Agent from \github.com/microsoft/agent-framework\.