### PR TITLE
feat(init): priority-based template sorting and manifest refresh

### DIFF
--- a/fnx/lib/host-launcher.js
+++ b/fnx/lib/host-launcher.js
@@ -253,9 +253,9 @@ function createLogFilter(verbose, hostState) {
       }
     }
 
-    // Worker indexing JSON (Python): extract non-HTTP trigger types from the indexed metadata
+    // Worker indexing JSON (Python): extract all functions from the indexed metadata
     // Format: {"message": "Successfully indexed function app.", "functions": "Function Name: X, Function Binding: [('triggerType', ...)] ..."}
-    if (line.includes('Successfully indexed function app')) {
+    if (line.includes('Successfully indexed function app') || line.includes('indexed function') || line.includes('Function Name:')) {
       const jsonStart = line.indexOf('{');
       if (jsonStart !== -1) {
         try {
@@ -268,12 +268,18 @@ function createLogFilter(verbose, hostState) {
             if (nameMatch && bindingMatch) {
               const name = nameMatch[1];
               const bindings = bindingMatch[1];
-              // Find all trigger bindings and pick the non-HTTP one if present
+              // Find all trigger bindings
               const allTriggers = [...bindings.matchAll(/\('(\w*[Tt]rigger)', '[^']*', '[^']*'\)/g)];
-              const nonHttpTrigger = allTriggers.find(m => m[1] !== 'httpTrigger');
-              if (nonHttpTrigger && !nonHttpFunctions.some(f => f.name === name)) {
-                nonHttpFunctions.push({ name, triggerType: nonHttpTrigger[1] });
-                if (hostState) hostState.nonHttpFunctions = [...nonHttpFunctions];
+              const trigger = allTriggers[0]; // First trigger binding
+              if (trigger) {
+                const triggerType = trigger[1];
+                // HTTP functions are tracked separately via URL detection
+                if (triggerType === 'httpTrigger') continue;
+                
+                if (!nonHttpFunctions.some(f => f.name === name)) {
+                  nonHttpFunctions.push({ name, triggerType });
+                  if (hostState) hostState.nonHttpFunctions = [...nonHttpFunctions];
+                }
               }
             }
           }
@@ -281,13 +287,44 @@ function createLogFilter(verbose, hostState) {
       }
     }
 
+    // Also detect functions from simpler log formats (e.g., .NET, Node.js)
+    // "Found the following functions: [func1, func2, ...]" or "Loading functions: ..."
+    const foundFunctionsMatch = line.match(/(?:Found the following functions|Loading functions):\s*\[([^\]]+)\]/i);
+    if (foundFunctionsMatch) {
+      const funcNames = foundFunctionsMatch[1].split(',').map(s => s.trim().replace(/['"]/g, ''));
+      for (const name of funcNames) {
+        if (name && !httpFunctions.some(f => f.name === name) && !nonHttpFunctions.some(f => f.name === name)) {
+          nonHttpFunctions.push({ name, triggerType: 'trigger' });
+          if (hostState) hostState.nonHttpFunctions = [...nonHttpFunctions];
+        }
+      }
+    }
+
     // Track invocations: "Executing 'Functions.hello' (Reason='...')"
     const execMatch = line.match(/Executing 'Functions\.(\w+)' \(Reason='([^']*)'/);
     if (execMatch) {
-      pendingInvocations.set(execMatch[1], {
-        reason: execMatch[2],
+      const funcName = execMatch[1];
+      const reason = execMatch[2];
+      
+      pendingInvocations.set(funcName, {
+        reason: reason,
         startTime: Date.now(),
       });
+      
+      // If this function isn't registered yet (e.g., timer triggers), add it now
+      if (!httpFunctions.some(f => f.name === funcName) && !nonHttpFunctions.some(f => f.name === funcName)) {
+        // Detect trigger type from reason (Timer fired, BlobCreated, etc.)
+        let triggerType = 'trigger';
+        if (reason.includes('Timer fired')) triggerType = 'timerTrigger';
+        else if (reason.includes('Blob')) triggerType = 'blobTrigger';
+        else if (reason.includes('Queue')) triggerType = 'queueTrigger';
+        else if (reason.includes('EventHub')) triggerType = 'eventHubTrigger';
+        else if (reason.includes('ServiceBus')) triggerType = 'serviceBusTrigger';
+        else if (reason.includes('Cosmos')) triggerType = 'cosmosDBTrigger';
+        
+        nonHttpFunctions.push({ name: funcName, triggerType });
+        if (hostState) hostState.nonHttpFunctions = [...nonHttpFunctions];
+      }
     }
 
     // Track invocation completions: "Executed 'Functions.hello' (Succeeded, Id=..., Duration=...ms)"
@@ -333,15 +370,26 @@ function createLogFilter(verbose, hostState) {
           console.log(`\t${funcName(fn.name)}: [${fn.methods}] ${urlColor(`${baseUrl}/${fn.route}`)}`);
         }
         for (const fn of nonHttpFunctions) {
+          fn._printed = true;
           console.log(`\t${funcName(fn.name)}: ${fn.triggerType}`);
         }
       } else {
-        console.log(dim(`\tNo functions found. Base URL: ${urlColor(baseUrl)}`));
+        // No functions detected from logs yet - they may appear on first invocation
+        console.log(dim(`\tBase URL: ${urlColor(baseUrl)}`));
       }
       if (!verbose) {
         console.log(dim('\nFor detailed output, run fnx with --verbose flag.'));
       }
       console.log();
+    }
+    
+    // When a new function is discovered after startup, print it
+    if (functionsShown && nonHttpFunctions.length > 0) {
+      const lastFn = nonHttpFunctions[nonHttpFunctions.length - 1];
+      if (!lastFn._printed) {
+        lastFn._printed = true;
+        console.log(`  ${funcName(lastFn.name)}: ${lastFn.triggerType} ${dim('(discovered)')}`);
+      }
     }
   }
 

--- a/fnx/lib/init.js
+++ b/fnx/lib/init.js
@@ -36,19 +36,24 @@ const RUNTIME_DISPLAY = {
 };
 
 /**
- * Priority order for templates by resource type.
- * Templates are sorted: 1) by resource priority, 2) by binding type (trigger > input > output), 3) alphabetically
+ * Priority order for displaying templates.
+ * 
+ * Templates are sorted by:
+ * 1. Priority bucket (P0 starters first, then P1 standard, then P2 advanced, etc.)
+ * 2. Resource order within each bucket (defined below)
+ * 3. Templates not in the resource order go at the end of their bucket
+ * 4. Alphabetical within same resource
+ * 
+ * Resource order per priority bucket:
+ * - P0 (Starter): HTTP, Timer, Blob, EventHub, MCP, HTTP (AI Agent uses http resource)
+ * - P1 (Standard): MCP, HTTP (ChatGPT), Durable, Cosmos, SQL, AgentFramework
+ * - P2 (Advanced): MCP, HTTP (AI samples), Durable, Bicep/Terraform/ARM
  */
-const TRIGGER_PRIORITY = [
-  'http',
-  'blob',
-  'timer',
-  'queue',
-  'servicebus',
-  'eventhub',
-  'durable',
-  'eventgrid',
-];
+const RESOURCE_ORDER_BY_PRIORITY = {
+  0: ['http', 'timer', 'blob', 'eventhub', 'mcp'],
+  1: ['mcp', 'http', 'durable', 'cosmos', 'sql', 'agentframework'],
+  2: ['mcp', 'http', 'durable', 'bicep', 'terraform', 'arm'],
+};
 
 /**
  * Main entry point for fnx init
@@ -72,7 +77,11 @@ export async function runInit(args) {
   
   let manifest;
   try {
-    manifest = await fetchManifest(MANIFEST_URL, { verbose: flags.verbose, backupUrl: MANIFEST_BACKUP_URL });
+    manifest = await fetchManifest(MANIFEST_URL, { 
+      verbose: flags.verbose, 
+      backupUrl: MANIFEST_BACKUP_URL,
+      refresh: flags.refresh,
+    });
   } catch (err) {
     console.error(errorColor(`\n✗ Cannot load template manifest`));
     console.error(dim(`
@@ -120,7 +129,7 @@ ${bold('✗ Invalid manifest format')}
   const filteredTemplates = filterTemplatesByRuntime(manifest, language);
   const template = flags.template
     ? findTemplateByName(filteredTemplates, flags.template)
-    : await promptTrigger(filteredTemplates, TRIGGER_PRIORITY);
+    : await promptTrigger(filteredTemplates, RESOURCE_ORDER_BY_PRIORITY);
 
   if (!template) {
     if (flags.template) {
@@ -408,6 +417,9 @@ function parseFlags(args) {
       case '-v':
         flags.verbose = true;
         break;
+      case '--refresh':
+        flags.refresh = true;
+        break;
       case '--env':
       case '-e':
         flags.env = true;
@@ -517,6 +529,7 @@ ${title('Options:')}
   ${success('--sku')} <sku>            Target SKU: flex (default), premium, dedicated.
   ${success('--env')}, ${success('-e')}             Setup dev environment (venv for Python, npm install for Node).
   ${success('--force')}, ${success('-f')}           Initialize in non-empty directory (overwrites template files only).
+  ${success('--refresh')}              Force refresh template manifest from CDN (bypass cache).
   ${success('--yes')}, ${success('-y')}             Accept all defaults (non-interactive).
   ${success('--verbose')}, ${success('-v')}         Show detailed output (manifest URL, cache, files).
   ${success('-h')}, ${success('--help')}            Show this help message.

--- a/fnx/lib/init/manifest.js
+++ b/fnx/lib/init/manifest.js
@@ -53,14 +53,15 @@ function filterTrustedTemplates(templates, defaultRepoUrl, verbose) {
  * @param {Object} options - Options
  * @param {boolean} options.verbose - Show detailed logging
  * @param {string} options.backupUrl - Backup URL to try if CDN fails
+ * @param {boolean} options.refresh - Force refresh from network (bypass cache)
  * @returns {Promise<{templates: Array}>} Parsed manifest
  */
 export async function fetchManifest(url, options = {}) {
-  const { verbose, backupUrl } = options;
+  const { verbose, backupUrl, refresh } = options;
 
-  // Check if cached manifest is still valid
+  // Check if cached manifest is still valid (unless refresh requested)
   const cached = await loadCachedManifest();
-  if (cached && !isExpired(cached.meta)) {
+  if (!refresh && cached && !isExpired(cached.meta)) {
     if (verbose) {
       const age = Math.round((Date.now() - cached.meta.fetchedAt) / 1000 / 60);
       console.log(`  Cache hit: manifest cached ${age} minutes ago`);
@@ -70,12 +71,16 @@ export async function fetchManifest(url, options = {}) {
     return cached.manifest;
   }
 
-  // Fetch from network with conditional request if we have ETag
+  if (refresh && verbose) {
+    console.log(`  Refresh requested, fetching from CDN...`);
+  }
+
+  // Fetch from network with conditional request if we have ETag (skip ETag if refresh)
   const headers = {};
-  if (cached?.meta?.etag) {
+  if (!refresh && cached?.meta?.etag) {
     headers['If-None-Match'] = cached.meta.etag;
     if (verbose) console.log(`  Cache stale, checking with ETag...`);
-  } else {
+  } else if (!refresh) {
     if (verbose) console.log(`  No cache, fetching from CDN...`);
   }
 

--- a/fnx/lib/init/prompts.js
+++ b/fnx/lib/init/prompts.js
@@ -504,14 +504,14 @@ export async function promptNodeLanguage() {
  * Shows top 9 templates with "More..." option for additional templates.
  * Supports type-to-filter search (3+ characters).
  * @param {Array} templates - Filtered templates for the selected runtime
- * @param {string[]} priorityOrder - Resource types in priority order
+ * @param {Object} resourceOrderByPriority - Resource order for each priority bucket
  * @returns {Promise<Object>} Selected template
  */
-export async function promptTrigger(templates, priorityOrder) {
+export async function promptTrigger(templates, resourceOrderByPriority) {
   const MAX_INITIAL_DISPLAY = 9;
   
-  // Sort all templates by resource priority
-  const sorted = sortTemplatesByResourcePriority(templates, priorityOrder);
+  // Sort all templates by priority bucket, then resource order within bucket
+  const sorted = sortTemplatesByPriorityAndResource(templates, resourceOrderByPriority);
   
   // Take top 9 for initial display
   const displayTemplates = sorted.slice(0, MAX_INITIAL_DISPLAY);
@@ -521,7 +521,7 @@ export async function promptTrigger(templates, priorityOrder) {
   const options = displayTemplates.map(template => ({
     value: template,
     label: formatTemplateLabel(template),
-    searchText: `${template.displayName || ''} ${template.id || ''} ${template.resource || ''} ${template.bindingType || ''}`,
+    searchText: `${template.displayName || ''} ${template.id || ''} ${template.category || ''} ${template.resource || ''} ${template.bindingType || ''}`,
   }));
 
   // Add separator and "More..." option if there are additional templates
@@ -548,64 +548,57 @@ export async function promptTrigger(templates, priorityOrder) {
   
   // If "More..." selected, show full list
   if (selected === '__MORE__') {
-    return promptTriggerAll(sorted, priorityOrder);
+    return promptTriggerAll(sorted, resourceOrderByPriority);
   }
   
   return selected;
 }
 
 /**
- * Sort templates by resource type priority, then by template priority (P0 starters first),
- * then by binding type within each resource.
+ * Sort templates by priority bucket first, then by resource order within each bucket.
  * 
  * Sort order:
- * 1. Resource type (http > blob > timer > queue > servicebus > eventhub > durable > eventgrid > other)
- * 2. Template priority (P0 starters > P1 > P2 samples)
- * 3. Binding type (trigger > input > output > other)
- * 4. Alphabetical by display name
+ * 1. Priority bucket (P0 starters > P1 standard > P2 advanced > P3, etc.)
+ * 2. Resource order within bucket (defined in resourceOrderByPriority)
+ * 3. Templates not in the resource order go at the end of their bucket
+ * 4. Alphabetical by display name within same resource
+ * 
+ * @param {Array} templates - Templates to sort
+ * @param {Object} resourceOrderByPriority - Map of priority number to resource order array
  */
-function sortTemplatesByResourcePriority(templates, priorityOrder) {
-  const bindingTypeOrder = { 'trigger': 0, 'input': 1, 'output': 2 };
-  
+function sortTemplatesByPriorityAndResource(templates, resourceOrderByPriority) {
   return [...templates].sort((a, b) => {
-    // 1. Sort by resource type priority
-    const aResource = (a.resource || 'other').toLowerCase();
-    const bResource = (b.resource || 'other').toLowerCase();
+    // 1. Sort by priority bucket (P0 first, then P1, P2, etc.)
+    const aPriority = a.priority ?? 999;
+    const bPriority = b.priority ?? 999;
     
-    const aIdx = priorityOrder.indexOf(aResource);
-    const bIdx = priorityOrder.indexOf(bResource);
+    if (aPriority !== bPriority) {
+      return aPriority - bPriority;
+    }
     
-    // Prioritized resources come first, others go to end alphabetically
-    const aResourcePriority = aIdx === -1 ? 999 : aIdx;
-    const bResourcePriority = bIdx === -1 ? 999 : bIdx;
+    // 2. Within same priority bucket: sort by resource order
+    const resourceOrder = resourceOrderByPriority[aPriority] || [];
+    const aResource = (a.resource || '').toLowerCase();
+    const bResource = (b.resource || '').toLowerCase();
+    
+    const aResourceIdx = resourceOrder.indexOf(aResource);
+    const bResourceIdx = resourceOrder.indexOf(bResource);
+    
+    // Resources in the defined order come first, others go to end
+    const aResourcePriority = aResourceIdx === -1 ? 999 : aResourceIdx;
+    const bResourcePriority = bResourceIdx === -1 ? 999 : bResourceIdx;
     
     if (aResourcePriority !== bResourcePriority) {
       return aResourcePriority - bResourcePriority;
     }
     
-    // If both unprioritized, sort alphabetically by resource
+    // 3. If both not in resource order, sort alphabetically by resource
     if (aResourcePriority === 999 && bResourcePriority === 999) {
       const resourceCmp = aResource.localeCompare(bResource);
       if (resourceCmp !== 0) return resourceCmp;
     }
     
-    // 2. Within same resource: sort by template priority (P0 starters first, then P1, P2 samples)
-    const aTemplatePriority = a.priority ?? 999;
-    const bTemplatePriority = b.priority ?? 999;
-    
-    if (aTemplatePriority !== bTemplatePriority) {
-      return aTemplatePriority - bTemplatePriority;
-    }
-    
-    // 3. Within same priority: sort by binding type (trigger > input > output)
-    const aBinding = bindingTypeOrder[a.bindingType] ?? 3;
-    const bBinding = bindingTypeOrder[b.bindingType] ?? 3;
-    
-    if (aBinding !== bBinding) {
-      return aBinding - bBinding;
-    }
-    
-    // 4. Alphabetical within same resource + priority + binding type
+    // 4. Alphabetical by display name within same resource
     return (a.displayName || a.id).localeCompare(b.displayName || b.id);
   });
 }
@@ -615,32 +608,30 @@ function sortTemplatesByResourcePriority(templates, priorityOrder) {
  */
 function formatTemplateLabel(template) {
   const name = template.displayName || template.id;
-  const resource = template.resource || 'other';
+  const category = template.category || template.resource || 'other';
   const bindingType = template.bindingType || '';
   
   // Show binding type for non-triggers
   if (bindingType && bindingType !== 'trigger') {
-    return `${funcName(name)} ${dim(`(${resource} ${bindingType})`)}`;
+    return `${funcName(name)} ${dim(`(${category} ${bindingType})`)}`;
   }
-  return `${funcName(name)} ${dim(`(${resource})`)}`;
+  return `${funcName(name)} ${dim(`(${category})`)}`;
 }
 
 /**
  * Show all templates when "More..." is selected
  * Uses search-enabled prompt for easy filtering
- * @param {Array} templates - All templates
- * @param {string[]} priorityOrder - Resource priority order
+ * @param {Array} templates - All templates (pre-sorted)
+ * @param {Object} resourceOrderByPriority - Resource order for each priority bucket (unused, templates pre-sorted)
  * @returns {Promise<object>} Selected template
  */
-async function promptTriggerAll(templates, priorityOrder) {
-  // Sort by resource priority, then binding type, then alphabetically
-  const sorted = sortTemplatesByResourcePriority(templates, priorityOrder);
-
-  const options = sorted.map(template => ({
+async function promptTriggerAll(templates, resourceOrderByPriority) {
+  // Templates are already pre-sorted, just use them directly
+  const options = templates.map(template => ({
     value: template,
     label: formatTemplateLabel(template),
     // Add searchText for improved search matching
-    searchText: `${template.displayName || ''} ${template.id || ''} ${template.resource || ''} ${template.bindingType || ''}`,
+    searchText: `${template.displayName || ''} ${template.id || ''} ${template.resource || ''} ${template.bindingType || ''} ${(template.categories || []).join(' ')}`,
   }));
 
   console.log(dim(`\n  Showing all ${options.length} templates (type to filter):\n`));

--- a/fnx/lib/init/scaffold.js
+++ b/fnx/lib/init/scaffold.js
@@ -614,7 +614,12 @@ async function replaceTemplatePlaceholders(targetDir, runtime, userVersion, verb
  */
 export function printSuccessBanner(targetDir, projectName, sku, runtime, envSetupDone = false) {
   const cwd = process.cwd();
-  const relativePath = targetDir === cwd ? '.' : targetDir.replace(cwd, '.').replace(/\\/g, '/');
+  // Normalize paths for comparison (handle Windows backslashes)
+  const normalizedTarget = resolve(targetDir);
+  const normalizedCwd = resolve(cwd);
+  const isCurrentDir = normalizedTarget === normalizedCwd;
+  
+  const relativePath = isCurrentDir ? '.' : targetDir.replace(cwd, '.').replace(/\\/g, '/');
 
   // Runtime-specific install steps (skip if --env already did setup)
   let installStep;
@@ -661,7 +666,7 @@ export function printSuccessBanner(targetDir, projectName, sku, runtime, envSetu
 
   // Adjust fnx start step number based on extra steps
   // Also adjust if we skip the cd step (when initializing in current directory)
-  const isCurrentDir = relativePath === '.';
+  // isCurrentDir is already computed above
   const cdStepOffset = isCurrentDir ? -1 : 0;
   const startStepNum = `${3 + extraSteps + cdStepOffset}.`;
 


### PR DESCRIPTION
## Summary

Improves the template selection experience in \nx init\ with priority-based sorting and adds cache control.

## Changes

### Template Sorting
- Sort templates by **priority bucket** (P0 starters → P1 standard → P2 advanced)
- Within each bucket, sort by **resource order** (e.g., P0: http → timer → blob → eventhub → mcp)
- Templates not in the defined order appear at the end of their bucket
- Added category to search text for better type-to-filter matching

### Manifest Cache
- Added \--refresh\ flag to force fetch manifest from CDN (bypasses cache and ETag check)
- Useful when testing new templates or debugging cache issues

### Non-HTTP Function Detection
- Improved detection of timer, blob, queue, eventhub, servicebus, cosmos triggers
- Functions discovered on first invocation are now printed dynamically
- Better parsing of Python worker indexing logs

### Bug Fix
- Fixed \cd\ step display when initializing in current directory (was showing \cd .\)

## Testing
- All 28 unit tests pass
- Manual testing needed for template sorting UX
